### PR TITLE
fix: tune gamepad look sensitivity

### DIFF
--- a/src/in_web.js
+++ b/src/in_web.js
@@ -287,14 +287,14 @@ function GP_Poll( cmd ) {
 	// Right stick → look (yaw + pitch), always active (no pointer lock required)
 	if ( rx !== 0 ) {
 
-		cl.viewangles[ YAW ] -= rx * cl_yawspeed.value * host_frametime * 2;
+		cl.viewangles[ YAW ] -= rx * cl_yawspeed.value * host_frametime * gp_look_yaw.value;
 
 	}
 
 	if ( ry !== 0 ) {
 
 		V_StopPitchDrift();
-		cl.viewangles[ PITCH ] += ry * cl_pitchspeed.value * host_frametime * 2;
+		cl.viewangles[ PITCH ] += ry * cl_pitchspeed.value * host_frametime * gp_look_pitch.value;
 		if ( cl.viewangles[ PITCH ] > 80 )
 			cl.viewangles[ PITCH ] = 80;
 		if ( cl.viewangles[ PITCH ] < - 70 )
@@ -307,6 +307,10 @@ function GP_Poll( cmd ) {
 // cvars (matching in_win.c)
 const m_filter = { name: 'm_filter', string: '0', value: 0 };
 const sensitivity = { name: 'sensitivity', string: '3', value: 3 };
+// Gamepad look tuning (standard mapping right stick).
+// Defaults keep yaw/pitch even, slightly reduced vs prior behavior.
+const gp_look_yaw = { name: 'gp_look_yaw', string: '1.5', value: 1.5 };
+const gp_look_pitch = { name: 'gp_look_pitch', string: '1.5', value: 1.5 };
 
 let in_initialized = false;
 
@@ -619,6 +623,8 @@ export function IN_Init( element ) {
 	// Register cvars
 	Cvar_RegisterVariable( sensitivity );
 	Cvar_RegisterVariable( m_filter );
+	Cvar_RegisterVariable( gp_look_yaw );
+	Cvar_RegisterVariable( gp_look_pitch );
 
 	// Register commands
 	Cmd_AddCommand( 'force_centerview', IN_ForceCenterView );

--- a/src/in_web.js
+++ b/src/in_web.js
@@ -308,9 +308,9 @@ function GP_Poll( cmd ) {
 const m_filter = { name: 'm_filter', string: '0', value: 0 };
 const sensitivity = { name: 'sensitivity', string: '3', value: 3 };
 // Gamepad look tuning (standard mapping right stick).
-// Defaults keep yaw/pitch even, slightly reduced vs prior behavior.
-const gp_look_yaw = { name: 'gp_look_yaw', string: '1.5', value: 1.5 };
-const gp_look_pitch = { name: 'gp_look_pitch', string: '1.5', value: 1.5 };
+// Defaults keep yaw/pitch even and slower than the prior hardcoded multiplier.
+const gp_look_yaw = { name: 'gp_look_yaw', string: '1', value: 1 };
+const gp_look_pitch = { name: 'gp_look_pitch', string: '1', value: 1 };
 
 let in_initialized = false;
 

--- a/src/in_web.js
+++ b/src/in_web.js
@@ -112,6 +112,24 @@ let _xrPrevRightTrigger = false;
 // Gamepad button edge detection (standard mapping)
 let _gpPrev = null;
 
+function GP_ReleaseAll() {
+
+	// If a controller disconnects mid-press, make sure nothing gets "stuck" down.
+	Key_Event( K_SPACE, false );
+	Key_Event( K_ENTER, false );
+	Key_Event( K_ESCAPE, false );
+	Key_Event( K_TAB, false );
+	Key_Event( K_SHIFT, false );
+	Key_Event( K_CTRL, false );
+	Key_Event( K_MOUSE1, false );
+	Key_Event( 'r'.charCodeAt( 0 ), false );
+	Key_Event( K_UPARROW, false );
+	Key_Event( K_DOWNARROW, false );
+	Key_Event( K_LEFTARROW, false );
+	Key_Event( K_RIGHTARROW, false );
+
+}
+
 function requestPointerLock() {
 
 	if ( pointerLocked || isQuest || targetElement == null ) return;
@@ -189,6 +207,7 @@ function GP_Poll( cmd ) {
 	const gp = GP_GetPrimary();
 	if ( ! gp ) {
 
+		if ( _gpPrev != null ) GP_ReleaseAll();
 		_gpPrev = null;
 		return;
 
@@ -208,8 +227,6 @@ function GP_Poll( cmd ) {
 			rt: false,
 			back: false,
 			start: false,
-			ls: false,
-			rs: false,
 			du: false,
 			dd: false,
 			dl: false,


### PR DESCRIPTION
- Replace hardcoded gamepad right-stick look multiplier with cvars (gp_look_yaw, gp_look_pitch).\n- Default yaw/pitch are evened out (1.5) and can be tuned via the console/config.